### PR TITLE
Feat/custom main button test (#52)

### DIFF
--- a/src/entities/NFCConfig.ts
+++ b/src/entities/NFCConfig.ts
@@ -4,6 +4,17 @@ import { Field, ID, ObjectType } from "type-graphql";
 import { User } from "./User";
 
 @ObjectType()
+class mainButton {
+  @Field(() => String)
+  @Property()
+  url: string = "";
+
+  @Field(() => String)
+  @Property()
+  text: string = "";
+}
+
+@ObjectType()
 export class SocialMediaSettings {
   @Field(() => Boolean)
   @Property()
@@ -52,9 +63,9 @@ export class NFCConfig {
   @Property({ type: "array" })
   nfcIds: string[] = [];
 
-  @Field(() => String)
-  @Property()
-  url!: string;
+  @Field(() => mainButton)
+  @Property({ type: mainButton })
+  mainButton!: mainButton;
 
   @Field(() => String)
   @Property()

--- a/src/migrations/Migration20240324AddMainButtonToNFCConfig.ts
+++ b/src/migrations/Migration20240324AddMainButtonToNFCConfig.ts
@@ -1,0 +1,48 @@
+import { Migration } from "@mikro-orm/migrations-mongodb";
+
+export class Migration20240324AddMainButtonToNFCConfig extends Migration {
+  async up(): Promise<void> {
+    // Get all NFCConfig documents
+    const nfcConfigs = await this.getCollection("nfcconfig").find({}).toArray();
+
+    // Update each document
+    for (const config of nfcConfigs) {
+      const updates: any = {
+        mainButton: {
+          url: config.url || "", // Transfer the old url value
+          text: "Visit Website", // Set default text
+        },
+      };
+
+      // Update the document
+      await this.getCollection("nfcconfig").updateOne(
+        { _id: config._id },
+        {
+          $set: updates,
+          $unset: { url: "" }, // Remove the old url field
+        }
+      );
+    }
+  }
+
+  async down(): Promise<void> {
+    // Get all NFCConfig documents
+    const nfcConfigs = await this.getCollection("nfcconfig").find({}).toArray();
+
+    // Update each document
+    for (const config of nfcConfigs) {
+      const updates: any = {
+        url: config.mainButton?.url || "", // Restore the old url field
+      };
+
+      // Update the document
+      await this.getCollection("nfcconfig").updateOne(
+        { _id: config._id },
+        {
+          $set: updates,
+          $unset: { mainButton: "" }, // Remove the mainButton field
+        }
+      );
+    }
+  }
+}

--- a/src/resolvers/Platform/NFCConfigResolver.ts
+++ b/src/resolvers/Platform/NFCConfigResolver.ts
@@ -37,15 +37,24 @@ class LinkSettingsInput {
 }
 
 @InputType()
-class NFCConfigInput {
+class MainButtonInput {
   @Field(() => String)
   url!: string;
 
+  @Field(() => String)
+  text!: string;
+}
+
+@InputType()
+class NFCConfigInput {
   @Field(() => String)
   title!: string;
 
   @Field(() => String)
   description!: string;
+
+  @Field(() => MainButtonInput)
+  mainButton!: MainButtonInput;
 
   @Field(() => SocialMediaSettingsInput, { nullable: true })
   socialMedia?: SocialMediaSettingsInput;
@@ -124,7 +133,7 @@ export class NFCConfigResolver {
     }
 
     const nfcConfig = em.create(NFCConfig, {
-      url: options.url,
+      mainButton: options.mainButton,
       title: options.title,
       description: options.description,
       owner: user,
@@ -174,7 +183,7 @@ export class NFCConfigResolver {
 
     try {
       em.assign(nfcConfig, {
-        url: options.url,
+        mainButton: options.mainButton,
         title: options.title,
         description: options.description,
         socialMedia: options.socialMedia,


### PR DESCRIPTION
* Enh/platform social share (#47)

* Small change

* Clean up

* Updated the nfc config entity to include socials

* Whoops

* Migration hell

* Should only use em assign

* Feat/nfc give (#48)

* Added two new fields to allow users to provide a link to give and a memberRegistrationLink

* Updated the resolver to include the new fields

* Migration

* Added a field to the nfc config entity to show events

* Updated the resolver

* Migration file

* Enh/links from string to obj (#50)

* Changed the link setting from a string to an object

* Updated the resolver

* Added migration to be ran after pushed to production

* Changed the main button url from a string to an object to include a way to change the text of the button

* Updated the resolver to use the new main button field

* Added a migration

* Removed the urls from the input type of the nfcconfiginput